### PR TITLE
Fixed issue with grabbing tags from a frozen registry object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # changelog
 
 ## Unreleased
-- /
+
+- Fixed an issue grabbing tags from frozen registries in FluidWrapper (#1173)
 
 ## [8.0.4] - 2026-07-23
 

--- a/src/main/java/dev/latvian/mods/kubejs/fluid/FluidWrapper.java
+++ b/src/main/java/dev/latvian/mods/kubejs/fluid/FluidWrapper.java
@@ -275,11 +275,10 @@ public interface FluidWrapper {
 		return switch (reader.peek()) {
 			case '#' -> {
 				reader.skip();
-				var tagKey = ID.read(reader).map(FluidTags::create);
-				yield tagKey.map(k -> {
-					var lookup = BuiltInRegistries.acquireBootstrapRegistrationLookup(BuiltInRegistries.FLUID);
-					return FluidIngredient.of(lookup.getOrThrow(k));
-				});
+				yield ID.read(reader).map(FluidTags::create).flatMap(k -> BuiltInRegistries.FLUID
+					.get(k)
+					.map(fluidNamed -> success(FluidIngredient.of(fluidNamed)))
+					.orElseGet(() -> error(() -> "Tag " + k.location() + " does not exist!")));
 			}
 			case '@' -> {
 				reader.skip();


### PR DESCRIPTION
This fixes the issue of FluidWrapper using frozen registries for tag lookup when in a runtime context.

Minimal reproduction code:
```js
ServerEvents.recipes(event => {
	console.log(Fluid.ingredientOf('#minecraft:water')) // net.neoforged.neoforge.fluids.crafting.SimpleFluidIngredient@54d18a62 [net.neoforged.neoforge.fluids.crafting.SimpleFluidIngredient]
})
```