### PR TITLE
Fix off-by-one in pack order construction

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/client/ClientAssetPacks.java
+++ b/src/main/java/dev/latvian/mods/kubejs/client/ClientAssetPacks.java
@@ -59,9 +59,10 @@ public class ClientAssetPacks {
 		int afterModsIndex = KubeFileResourcePack.findAfterModsIndex(packs);
 
 		packs.add(beforeModsIndex, virtualPacks.get(GeneratedDataStage.BEFORE_MODS));
-		packs.add(afterModsIndex, internalAssetPack);
-		packs.add(afterModsIndex + 1, virtualPacks.get(GeneratedDataStage.AFTER_MODS));
-		packs.addAll(afterModsIndex + 2, filePacks);
+		// Each entry index is incremented to account for the fact that we've inserted entries before it
+		packs.add(afterModsIndex + 1, internalAssetPack);
+		packs.add(afterModsIndex + 2, virtualPacks.get(GeneratedDataStage.AFTER_MODS));
+		packs.addAll(afterModsIndex + 3, filePacks);
 		packs.add(virtualPacks.get(GeneratedDataStage.LAST));
 
 		internalAssetPack.reset();


### PR DESCRIPTION
Without this patch, assets from the last pack provided by a mod are always loaded after `AFTER_MODS`/internal/file packs. In my use case this caused KubeJS to be unable to override translations of one specific mod.

I know exactly zero Java, but hopefully this works.